### PR TITLE
Added support for downloading TikTok Slideshows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TikTokDL
 
-A python package to download TikTok videos or Slideshows by URL without needing to login.
+A python package to download TikTok videos or slideshows by URL without needing to login.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ python -m playwright install-deps
 2. Import the package
 
 ```python
-from tiktokdl.download_video import get_video
+from tiktokdl.download_post import get_post
 ```
 
 3. Run the function in an async context
@@ -33,7 +33,7 @@ from tiktokdl.download_video import get_video
 video_url = ""
 
 video_info = asyncio.run(
-    get_video(
+    get_post(
         video_url
     )
 )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # TikTokDL
 
-A python package that downloads TikTok videos by URL
-
-## TODO
-
-- Enable downloading of video slideshows
+A python package to download TikTok videos or Slideshows by URL without needing to login.
 
 ## Usage
 
@@ -30,11 +26,11 @@ from tiktokdl.download_post import get_post
 3. Run the function in an async context
 
 ```python
-video_url = ""
+video_or_slide_url = ""
 
 video_info = asyncio.run(
     get_post(
-        video_url
+        video_or_slide_url
     )
 )
 ```

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "numpy",
         "opencv-python",
     ],
-    description="A package to dowload TikTok videos via URL",
+    description="A package to download TikTok videos or slideshows by URL without needing to login",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_packages
 
 setup(
     name="tiktok-dlpy",
-    version="1.2.0",
+    version="1.3.0",
     url="https://github.com/Fluxticks/TikTokDL",
-    download_url="https://github.com/Fluxticks/TikTokDL/archive/v1.2.0.tar.gz",
+    download_url="https://github.com/Fluxticks/TikTokDL/archive/v1.3.0.tar.gz",
     author="Fluxticks",
     packages=find_packages(),
     install_requires=[

--- a/tiktokdl/download_post.py
+++ b/tiktokdl/download_post.py
@@ -286,7 +286,7 @@ async def get_post(
         await __close_popups(video_page)
 
         if isinstance(video_info, TikTokSlide):
-            await download_slideshow(video_page, video_info)
+            await download_slideshow(video_info)
             return video_info
 
         if force_download_strategy:
@@ -364,7 +364,7 @@ async def alternate_download_strategy(playwright_page: Page, video_info: TikTokV
         video_info.file_path = save_path
 
 
-async def download_slideshow(playwright_page: Page, video_info: TikTokSlide):
+async def download_slideshow(video_info: TikTokSlide):
     images = []
     for idx, image_info in enumerate(video_info.images):
         image_url = image_info.get("imageURL").get("urlList")[-1]

--- a/tiktokdl/download_post.py
+++ b/tiktokdl/download_post.py
@@ -16,7 +16,7 @@ from tiktokdl.exceptions import CaptchaFailedException, DownloadFailedException,
 from tiktokdl.image_processing import find_position, image_from_url
 from tiktokdl.video_data import TikTokVideo
 
-__all__ = ["get_video"]
+__all__ = ["get_post"]
 
 
 def __parse_captcha_params_from_url(url: str) -> dict:
@@ -40,7 +40,7 @@ async def __get_captcha_response_headers(request: Request) -> dict:
     return all_headers
 
 
-def __parse_video_info(page_source: str) -> TikTokVideo:
+def __parse_post_info(page_source: str) -> TikTokVideo:
     soup = BeautifulSoup(page_source, "lxml")
     script_data = soup.find("script", attrs={"id": "SIGI_STATE"})
     data = json.loads(script_data.text)
@@ -191,7 +191,7 @@ def __filter_kwargs(function: callable, all_kwargs: dict):
     return valid_kwargs
 
 
-async def get_video(
+async def get_post(
     url: str,
     download: bool = True,
     force_download_strategy: Literal["primary",
@@ -255,7 +255,7 @@ async def get_video(
 
         try:
             page_source = await video_page.content()
-            video_info = __parse_video_info(page_source)
+            video_info = __parse_post_info(page_source)
         except:
             raise ResponseParseException(url)
 

--- a/tiktokdl/download_post.py
+++ b/tiktokdl/download_post.py
@@ -14,7 +14,7 @@ from playwright.async_api import async_playwright
 
 from tiktokdl.exceptions import CaptchaFailedException, DownloadFailedException, ResponseParseException
 from tiktokdl.image_processing import find_position, image_from_url
-from tiktokdl.video_data import TikTokVideo
+from tiktokdl.post_data import TikTokVideo, TikTokSlide, TikTokPost
 
 __all__ = ["get_post"]
 
@@ -40,7 +40,11 @@ async def __get_captcha_response_headers(request: Request) -> dict:
     return all_headers
 
 
-def __parse_post_info(page_source: str) -> TikTokVideo:
+def __is_image_post(post_data: dict) -> bool:
+    return post_data.get("imagePost") is not None
+
+
+def __parse_post_info(page_source: str) -> TikTokVideo | TikTokSlide:
     soup = BeautifulSoup(page_source, "lxml")
     script_data = soup.find("script", attrs={"id": "SIGI_STATE"})
     data = json.loads(script_data.text)
@@ -53,33 +57,45 @@ def __parse_post_info(page_source: str) -> TikTokVideo:
     avatar = author_data.get("avatarThumb")
     author_url = f"https://www.tiktok.com/@{username}/"
 
-    video_data = list(data.get("ItemModule").values())[0]
-    video_description = video_data.get("desc")
-    video_download_setting = video_data.get("downloadSetting")
-    video_id = video_data.get("id")
-    timestamp = datetime.fromtimestamp(int(video_data.get("createTime")))
-    like_count = video_data.get("stats").get("diggCount")
-    share_count = video_data.get("stats").get("shareCount")
-    comment_count = video_data.get("stats").get("commentCount")
-    view_count = video_data.get("stats").get("playCount")
-    video_thumbnail = video_data.get("video").get("originCover")
+    post_data = list(data.get("ItemModule").values())[0]
 
-    return TikTokVideo(
-        url=post_url,
-        video_id=video_id,
-        author_username=username,
-        author_display_name=display_name,
-        author_avatar=avatar,
-        author_url=author_url,
-        video_download_setting=video_download_setting,
-        video_description=video_description,
-        timestamp=timestamp,
-        like_count=like_count,
-        share_count=share_count,
-        comment_count=comment_count,
-        view_count=view_count,
-        video_thumbnail=video_thumbnail,
+    post_description = post_data.get("desc")
+    post_download_setting = post_data.get("downloadSetting")
+    post_id = post_data.get("id")
+    timestamp = datetime.fromtimestamp(int(post_data.get("createTime")))
+    like_count = post_data.get("stats").get("diggCount")
+    share_count = post_data.get("stats").get("shareCount")
+    comment_count = post_data.get("stats").get("commentCount")
+    view_count = post_data.get("stats").get("playCount")
+
+    post = TikTokPost(
+            url=post_url,
+            post_id=post_id,
+            author_username=username,
+            author_display_name=display_name,
+            author_avatar=avatar,
+            author_url=author_url,
+            post_download_setting=post_download_setting,
+            post_description=post_description,
+            timestamp=timestamp,
+            like_count=like_count,
+            share_count=share_count,
+            comment_count=comment_count,
+            view_count=view_count
     )
+
+    if __is_image_post(post_data):
+        images = post_data.get("imagePost").get("images")
+        return TikTokSlide(
+            **post.__dict__,
+            images=images
+        )
+    else:
+        video_thumbnail = post_data.get("video").get("originCover")
+        return TikTokVideo(
+             **post.__dict__,
+            video_thumbnail=video_thumbnail
+        )
 
 
 def __generate_random_captcha_steps(piece_position: tuple[int, int], tip_y_value: int):
@@ -206,7 +222,7 @@ async def get_post(
     headless: bool | None = None,
     slow_mo: float | None = None,
     **kwargs: dict
-) -> TikTokVideo:
+) -> TikTokVideo | TikTokSlide:
     """Get the information about a given video URL. If the `download` param is set to True, also download the video as an mp4 file.
 
     Args:

--- a/tiktokdl/download_post.py
+++ b/tiktokdl/download_post.py
@@ -365,6 +365,11 @@ async def alternate_download_strategy(playwright_page: Page, video_info: TikTokV
 
 
 async def download_slideshow(video_info: TikTokSlide):
+    """For a given Slideshow post, download the images associated with it.
+
+    Args:
+        video_info (TikTokSlide): The Slideshow post data.
+    """
     images = []
     for idx, image_info in enumerate(video_info.images):
         image_url = image_info.get("imageURL").get("urlList")[-1]

--- a/tiktokdl/post_data.py
+++ b/tiktokdl/post_data.py
@@ -3,19 +3,28 @@ from datetime import datetime
 
 
 @dataclass()
-class TikTokVideo:
+class TikTokPost:
     url: str
-    video_id: str
+    post_id: str
     author_username: str
     author_display_name: str
     author_avatar: str
     author_url: str
-    video_download_setting: int
-    video_description: str
+    post_download_setting: int
+    post_description: str
     timestamp: datetime
     like_count: int
     share_count: int
     comment_count: int
     view_count: int
+
+
+@dataclass()
+class TikTokVideo(TikTokPost):
     video_thumbnail: str
     file_path: str = None
+
+
+@dataclass()
+class TikTokSlide(TikTokPost):
+    images: list[str] = None


### PR DESCRIPTION
Minor refactoring to add support for downloading TikTok slideshow URLs

### Changes 
- Changed `download_video` package to `download_post`
- Changed `video_data` package to `post_data`
- Changed `get_video` function to `get_post`
- `TikTokVideo` is now a subclass of `TikTokPost` and a sibling of `TikTokSlide`
- Some internal functions were renamed to refer to "posts" rather than "videos"